### PR TITLE
Fix column number in gap docs

### DIFF
--- a/src/pages/docs/gap.mdx
+++ b/src/pages/docs/gap.mdx
@@ -55,7 +55,7 @@ Use `gap-x-{size}` and `gap-y-{size}` to change the gap between rows and columns
   </div>
 </template>
 
-<div class="grid **gap-x-8** **gap-y-4** grid-cols-2">
+<div class="grid **gap-x-8** **gap-y-4** grid-cols-3">
   <div>1</div>
   <div>2</div>
   <div>3</div>


### PR DESCRIPTION
The number of columns was wrong in the class to compare to the template.